### PR TITLE
Jacdac Extension

### DIFF
--- a/jacdac/README.md
+++ b/jacdac/README.md
@@ -1,0 +1,1 @@
+# Jacdac blocks for the Kitronik motor driver

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -1,0 +1,58 @@
+//% deprecated
+namespace kitronik_motor_driver { }
+
+namespace modules {
+    /**
+     * Motor 1 client
+     */
+    //% fixedInstance whenUsed block="kitronik motor1"
+    export const kitronikMotor1 = new MotorClient("kitronik motor1?device=self")
+
+    /**
+     * Motor 2 client
+     */
+    //% fixedInstance whenUsed block="kitronik motor2"
+    export const kitronikMotor2 = new MotorClient("kitronik motor2?device=self")
+}
+
+namespace servers {
+    class MotorServer extends jacdac.Server {
+        motor: kitronik_motor_driver.Motors
+        speed: number
+        enabled: boolean
+
+        constructor(motor: kitronik_motor_driver.Motors) {
+            super(jacdac.SRV_MOTOR)
+            this.motor = motor
+            this.enabled = false
+
+            kitronik_motor_driver.motorOff(this.motor)
+        }
+
+        handlePacket(pkt: jacdac.JDPacket) {
+            this.handleRegValue(pkt, jacdac.MotorReg.Reversible, jacdac.MotorRegPack.Reversible, true)
+            this.speed = this.handleRegValue(pkt, jacdac.MotorReg.Duty, jacdac.MotorRegPack.Duty, this.speed)
+            this.enabled = this.handleRegBool(pkt, jacdac.MotorReg.Enabled, this.enabled)
+
+            this.sync()
+        }
+        
+        sync() {
+            if (!this.enabled)
+                kitronik_motor_driver.motorOff(this.motor)
+            else {
+                const direction = this.speed < 0 ? kitronik_motor_driver.MotorDirection.Reverse
+                    : kitronik_motor_driver.MotorDirection.Forward
+                kitronik_motor_driver.motorOn(this.motor, direction, Math.abs(this.speed))
+            }
+        }
+    }
+    jacdac.productIdentifier = 0x31ee311d
+    function start() {
+        jacdac.startSelfServers(() => [
+            new MotorServer(kitronik_motor_driver.Motors.Motor1),
+            new MotorServer(kitronik_motor_driver.Motors.Motor2)
+        ])
+    }
+    start()
+}

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -49,6 +49,7 @@ namespace servers {
     }
     function start() {
         jacdac.productIdentifier = 0x31ee311d
+        jacdac.deviceDescription = "Kitronik Motor Driver"
         jacdac.startSelfServers(() => [
             new MotorServer(kitronik_motor_driver.Motors.Motor1),
             new MotorServer(kitronik_motor_driver.Motors.Motor2)

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -47,8 +47,8 @@ namespace servers {
             }
         }
     }
-    jacdac.productIdentifier = 0x31ee311d
     function start() {
+        jacdac.productIdentifier = 0x31ee311d
         jacdac.startSelfServers(() => [
             new MotorServer(kitronik_motor_driver.Motors.Motor1),
             new MotorServer(kitronik_motor_driver.Motors.Motor2)

--- a/jacdac/main.ts
+++ b/jacdac/main.ts
@@ -6,13 +6,13 @@ namespace modules {
      * Motor 1 client
      */
     //% fixedInstance whenUsed block="kitronik motor1"
-    export const kitronikMotor1 = new MotorClient("kitronik motor1?device=self")
+    export const kitronikMotor1 = new MotorClient("kitronik motor1?dev=self&srvo=0")
 
     /**
      * Motor 2 client
      */
     //% fixedInstance whenUsed block="kitronik motor2"
-    export const kitronikMotor2 = new MotorClient("kitronik motor2?device=self")
+    export const kitronikMotor2 = new MotorClient("kitronik motor2?dev=self&srvo=1")
 }
 
 namespace servers {
@@ -31,7 +31,7 @@ namespace servers {
 
         handlePacket(pkt: jacdac.JDPacket) {
             this.handleRegValue(pkt, jacdac.MotorReg.Reversible, jacdac.MotorRegPack.Reversible, true)
-            this.speed = this.handleRegValue(pkt, jacdac.MotorReg.Duty, jacdac.MotorRegPack.Duty, this.speed)
+            this.speed = this.handleRegValue(pkt, jacdac.MotorReg.Speed, jacdac.MotorRegPack.Speed, this.speed)
             this.enabled = this.handleRegBool(pkt, jacdac.MotorReg.Enabled, this.enabled)
 
             this.sync()

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:KitronikLtd/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.41",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.41"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.53",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.53"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.9.5",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.9.5"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.2",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.2"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.22",
+        "target": "4.1.24",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.2",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.2"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.3"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.23"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.27"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.15",
+    "version": "0.0.16",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.14"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.23",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.23"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.27",
+        "target": "4.1.30",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.5"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.14",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.14"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.24",
+        "target": "4.1.27",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,0 +1,26 @@
+{
+    "name": "kitronik-motor-driver-jacdac",
+    "dependencies": {
+        "core": "*",
+        "radio": "*",
+        "microphone": "*",
+        "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
+        "jacdac": "github:microsoft/pxt-jacdac#v0.9.5",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.9.5"
+    },
+    "files": [
+        "main.ts",
+        "README.md"
+    ],
+    "testFiles": [
+        "test.ts"
+    ],
+    "targetVersions": {
+        "target": "4.1.22",
+        "targetId": "microbit"
+    },
+    "supportedTargets": [
+        "microbit"
+    ],
+    "preferredEditor": "tsprj"
+}

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.3",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.3"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.5",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.5"
     },
     "files": [
         "main.ts",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,5 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
+    "version": "0.0.8",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.13",
+    "version": "0.0.14",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -6,8 +6,8 @@
         "radio": "*",
         "microphone": "*",
         "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.27",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.27"
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.31",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.31"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.30",
+        "target": "4.1.34",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -5,9 +5,9 @@
         "core": "*",
         "radio": "*",
         "microphone": "*",
-        "pxt-kitronik-motor-driver": "github:pelikhan/pxt-kitronik-motor-driver",
-        "jacdac": "github:microsoft/pxt-jacdac#v0.10.31",
-        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.31"
+        "pxt-kitronik-motor-driver": "github:KitronikLtd/pxt-kitronik-motor-driver",
+        "jacdac": "github:microsoft/pxt-jacdac#v0.10.41",
+        "jacdac-motor": "github:microsoft/pxt-jacdac/motor#v0.10.41"
     },
     "files": [
         "main.ts",
@@ -17,7 +17,7 @@
         "test.ts"
     ],
     "targetVersions": {
-        "target": "4.1.34",
+        "target": "4.1.45",
         "targetId": "microbit"
     },
     "supportedTargets": [

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/pxt.json
+++ b/jacdac/pxt.json
@@ -1,6 +1,6 @@
 {
     "name": "kitronik-motor-driver-jacdac",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "dependencies": {
         "core": "*",
         "radio": "*",

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -2,7 +2,7 @@ let speed = 0
 let dv = 5
 forever(() => {
     modules.kitronikMotor1.run(speed)
-    modules.kitronikMotor2.run(1 - speed)
+    modules.kitronikMotor2.run(- speed)
 
     speed += dv
     if (speed > 100) {

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -1,0 +1,17 @@
+let speed = 0
+let dv = 5
+forever(() => {
+    modules.kitronikMotor1.setEnabled(true)
+    modules.kitronikMotor2.setEnabled(true)
+
+    modules.kitronikMotor1.setDuty(speed)
+    modules.kitronikMotor2.setDuty(1 - speed)
+
+    speed += dv
+    if (speed > 100) {
+        dv = -5
+    } else if (speed < -100) {
+        dv = 5
+    }
+    pause(250)
+})

--- a/jacdac/test.ts
+++ b/jacdac/test.ts
@@ -1,11 +1,8 @@
 let speed = 0
 let dv = 5
 forever(() => {
-    modules.kitronikMotor1.setEnabled(true)
-    modules.kitronikMotor2.setEnabled(true)
-
-    modules.kitronikMotor1.setDuty(speed)
-    modules.kitronikMotor2.setDuty(1 - speed)
+    modules.kitronikMotor1.run(speed)
+    modules.kitronikMotor2.run(1 - speed)
 
     speed += dv
     if (speed > 100) {


### PR DESCRIPTION
This pull requests add support for Jacdac for this accessory which allows users to use simulators in MakeCode. Jacdac support will be released in the next major release of MakeCode for micro:bit (summer 2022).

-   This change adds a new nested extension (`jacdac` folder)
and does not modify the existing extension. **Your existing lessons, tutorials and blocks are not impacted by this change.**
-   No hardware modification is required for existing accessories, this feature
is [backward compatible](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/). However, it requires a micro:bit V2 to run.

The benefits for the users and you will be:

-   **Simulator** Jacdac enables simulations of all sensors and actuators
-   **Digital twins** Jacdac surfaces the hardware state directly into the MakeCode editor
-   **Standardized blocks and lessons** the programming will be done through
Jacdac blocks maintained by the Microsoft team

We recommend reading the [Jacdac software only accessory](https://microsoft.github.io/jacdac-docs/ddk/microbit/software-only-accessory/) documentation page to learn more 
about the details of this approach. You can also review a list of similar [software only extensions](https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/).

Please do not hesitate to contact us through this pull request or at jacdac-tap@microsoft.com 
if you have any question or want to schedule a call.

## How to test this extension as a user?

**This features requires to beta editor of MakeCode at https://makecode.microbit.org/beta.**

- Click on https://microsoft.github.io/jacdac-docs/ddk/microbit/extension-samples/
- Find the extension for this accessory
- Click on **Try MakeCode** to open a project that as a user
- Use the blocks from the **Modules** toolbox

You can follow the [micro:bit Jacdac guide](https://microsoft.github.io/jacdac-docs/clients/makecode/) to learn how Jacdac integrates into MakeCode

## TODOs

- [ ] merge this pull request (**squash recommended**)
- [ ] create a new release for the repository

```
npx makecode bump --patch
```

- [ ] review the accessory page in the [Jacdac device catalog](https://microsoft.github.io/jacdac-docs/devices/) to make sure we got all the details right

Once the pull request is merged, we will update the catalog to point to it rather than our temporary fork.

## Future accessories TODOs

- Review the [micro:bit accessory Jacdac integration guide](https://microsoft.github.io/jacdac-docs/ddk/microbit/) to learn how you can integrate Jacdac into your future accessories for a better user experience. We provide various options to integrate Jacdac into your hardware at minimal cost.
- Review the [Jacdac Device Development Kit](https://microsoft.github.io/jacdac-docs/ddk/) for more details about hardware integration of Jacdac in general.
- Contact us if you have any question about adding Jacdac to your next accessory through [Discussions](https://github.com/microsoft/jacdac/discussions) or at jacdac-tag@microsoft.com.